### PR TITLE
MPMI-910 simplify build and run setup, support running on mac OS, rem…

### DIFF
--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,2 +1,0 @@
-CONF_FOLDER=${PWD}/conf
-SCHEMA_FOLDER=${PWD}/schemas

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,11 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ${CONF_FOLDER}
+      device: ${PWD}/conf
       o: bind
   ldsmemoryschemas:
     driver: local
     driver_opts:
       type: none
-      device: ${SCHEMA_FOLDER}
+      device: ${PWD}/schemas
       o: bind

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -11,9 +11,4 @@ else
   echo "Reusing existing volumes and data"
 fi
 
-ENV_FILE='docker-compose.env'
-if [ -f $ENV_FILE ]; then
-    export $(grep -v '^#' $ENV_FILE | envsubst | xargs -0)
-fi
-
 docker-compose up --remove-orphans


### PR DESCRIPTION
The current run-dev.sh file does not work on Mac as envsubst is an external executable and not part of Bash.
Fixed by removing env file and move folder config to docker-compose file.